### PR TITLE
add metrics of spare nodes and status of reconciliation

### DIFF
--- a/e2e/nyallocator_test.go
+++ b/e2e/nyallocator_test.go
@@ -97,16 +97,22 @@ var _ = Describe("nyallocator e2e test", func() {
 			g.Expect(string(metrics)).To(ContainSubstring(`nyallocator_current_nodes{nodetemplate="control-plane"} 3`))
 			g.Expect(string(metrics)).To(ContainSubstring(`nyallocator_desired_nodes{nodetemplate="control-plane"} 3`))
 			g.Expect(string(metrics)).To(ContainSubstring(`nyallocator_sufficient_nodes{nodetemplate="control-plane"} 1`))
+			g.Expect(string(metrics)).To(ContainSubstring(`nyallocator_spare_nodes{nodetemplate="control-plane"} 0`))
+			g.Expect(string(metrics)).To(ContainSubstring(`nyallocator_reconcile_success{nodetemplate="control-plane"} 1`))
 
 			g.Expect(string(metrics)).To(ContainSubstring(`nyallocator_current_nodes{nodetemplate="cs"} 2`))
 			g.Expect(string(metrics)).To(ContainSubstring(`nyallocator_desired_nodes{nodetemplate="cs"} 2`))
 			g.Expect(string(metrics)).To(ContainSubstring(`nyallocator_sufficient_nodes{nodetemplate="cs"} 1`))
+			g.Expect(string(metrics)).To(ContainSubstring(`nyallocator_spare_nodes{nodetemplate="cs"} 1`))
+			g.Expect(string(metrics)).To(ContainSubstring(`nyallocator_reconcile_success{nodetemplate="cs"} 1`))
 
 			g.Expect(string(metrics)).To(ContainSubstring(`nyallocator_current_nodes{nodetemplate="ss"} 2`))
 			g.Expect(string(metrics)).To(ContainSubstring(`nyallocator_desired_nodes{nodetemplate="ss"} 2`))
 			g.Expect(string(metrics)).To(ContainSubstring(`nyallocator_sufficient_nodes{nodetemplate="ss"} 1`))
-		}).WithTimeout(10 * time.Second).WithPolling(500 * time.Millisecond).Should(Succeed())
+			g.Expect(string(metrics)).To(ContainSubstring(`nyallocator_spare_nodes{nodetemplate="ss"} 1`))
+			g.Expect(string(metrics)).To(ContainSubstring(`nyallocator_reconcile_success{nodetemplate="ss"} 1`))
 
+		}).WithTimeout(10 * time.Second).WithPolling(500 * time.Millisecond).Should(Succeed())
 	})
 
 	It("should allocate node when templates are updated", func() {

--- a/internal/controller/metrics.go
+++ b/internal/controller/metrics.go
@@ -20,11 +20,20 @@ var (
 		Name:      "desired_nodes",
 		Help:      "Number of nodes specified in the NodeTemplate",
 	}, []string{"nodetemplate"})
-
+	SpareNodesVec = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Namespace: metricsNamespace,
+		Name:      "spare_nodes",
+		Help:      "Number of spare nodes matching the NodeTemplate",
+	}, []string{"nodetemplate"})
 	SufficientNodesVec = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 		Namespace: metricsNamespace,
 		Name:      "sufficient_nodes",
-		Help:      "Whether Number of nodes under NodeTemplate is sufficient or not",
+		Help:      "Whether number of nodes under the NodeTemplate is sufficient or not",
+	}, []string{"nodetemplate"})
+	ReconcileSuccessVec = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Namespace: metricsNamespace,
+		Name:      "reconcile_success",
+		Help:      "Whether reconciliations of the NodeTemplate is successful or not",
 	}, []string{"nodetemplate"})
 )
 
@@ -32,4 +41,6 @@ func init() {
 	metrics.Registry.MustRegister(CurrentNodesVec)
 	metrics.Registry.MustRegister(DesiredNodesVec)
 	metrics.Registry.MustRegister(SufficientNodesVec)
+	metrics.Registry.MustRegister(SpareNodesVec)
+	metrics.Registry.MustRegister(ReconcileSuccessVec)
 }


### PR DESCRIPTION
This PR contains the following changes.

- Add two metrics
  - `nyallocator_spare_nodes`
    - exports number of spare nodes that matched the NodeTemplate's selector
  - `nyallocator_reconcile_success`
    - exports .status.conditions.ReconcileSuccess 
 - fix incorrect variable name (refactoring)


`nyallocator_spare_nodes` is updates in `NodeReconciler` because `NodeTemplateReconciler` is triggered only when NodeTemplate changes and under management node changes.