### PR TITLE
fix condition of Reconciler triggers

### DIFF
--- a/internal/controller/node_controller.go
+++ b/internal/controller/node_controller.go
@@ -9,7 +9,6 @@ import (
 	"k8s.io/apimachinery/pkg/labels"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/controller"
 )
 
 // +kubebuilder:rbac:groups=core,resources=nodes,verbs=get;list;watch;update;patch
@@ -75,7 +74,7 @@ func (r *NodeReconciler) updateMetrics(ctx context.Context) error {
 func (r *NodeReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&corev1.Node{}).
+		WithEventFilter(taintChangePredicate()).
 		Named("node").
-		WithOptions(controller.Options{MaxConcurrentReconciles: 1}).
 		Complete(r)
 }

--- a/internal/controller/node_controller_test.go
+++ b/internal/controller/node_controller_test.go
@@ -94,7 +94,7 @@ var _ = Describe("NodeTemplate Controller", func() {
 				err = k8sClient.Get(ctx, client.ObjectKey{Name: "node1"}, nodeToUpdate)
 				g.Expect(err).ToNot(HaveOccurred())
 				nodeToUpdate.Spec.Taints = append(nodeToUpdate.Spec.Taints, corev1.Taint{
-					Key:    SpareTaintKey,
+					Key:    "node.cybozu.io/spare",
 					Value:  "true",
 					Effect: corev1.TaintEffectNoSchedule,
 				})

--- a/internal/controller/node_controller_test.go
+++ b/internal/controller/node_controller_test.go
@@ -9,6 +9,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/utils/ptr"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/config"
 	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
 )
@@ -78,6 +79,35 @@ var _ = Describe("NodeTemplate Controller", func() {
 						g.Expect(node.Labels).To(HaveKeyWithValue("test-label", "foo"))
 					}
 				}
+			}).WithTimeout(10 * time.Second).WithPolling(500 * time.Millisecond).Should(Succeed())
+		})
+
+		It("should add spare label when spare taint is added to existing node", func() {
+			By("creating Node without spare taint")
+			node := newNode("node1").withLabel(map[string]string{"node-role.kubernetes.io/worker": "true"}).build()
+			err := k8sClient.Create(ctx, &node)
+			Expect(err).ToNot(HaveOccurred())
+
+			By("adding spare taint to the Node")
+			Eventually(func(g Gomega) {
+				nodeToUpdate := &corev1.Node{}
+				err = k8sClient.Get(ctx, client.ObjectKey{Name: "node1"}, nodeToUpdate)
+				g.Expect(err).ToNot(HaveOccurred())
+				nodeToUpdate.Spec.Taints = append(nodeToUpdate.Spec.Taints, corev1.Taint{
+					Key:    SpareTaintKey,
+					Value:  "true",
+					Effect: corev1.TaintEffectNoSchedule,
+				})
+				err = k8sClient.Update(ctx, nodeToUpdate)
+				g.Expect(err).ToNot(HaveOccurred())
+			}).WithTimeout(10 * time.Second).WithPolling(500 * time.Millisecond).Should(Succeed())
+
+			By("checking Node status")
+			Eventually(func(g Gomega) {
+				updatedNode := &corev1.Node{}
+				err := k8sClient.Get(ctx, client.ObjectKey{Name: "node1"}, updatedNode)
+				g.Expect(err).NotTo(HaveOccurred())
+				g.Expect(updatedNode.Labels).To(HaveKeyWithValue("node-role.kubernetes.io/spare", "true"))
 			}).WithTimeout(10 * time.Second).WithPolling(500 * time.Millisecond).Should(Succeed())
 		})
 	})

--- a/internal/controller/nodetemplate_controller.go
+++ b/internal/controller/nodetemplate_controller.go
@@ -444,9 +444,9 @@ func (r *NodeTemplateReconciler) SetupWithManager(mgr ctrl.Manager) error {
 			builder.WithPredicates(
 				predicate.And(
 					predicate.Or(
-						predicate.GenerationChangedPredicate{}, // when Spec changes
 						predicate.LabelChangedPredicate{},
 						predicate.AnnotationChangedPredicate{},
+						taintChangePredicate(),
 					),
 					predicate.NewTypedPredicateFuncs(func(object client.Object) bool {
 						if _, ok := object.GetLabels()[NodeTemplateReferenceLabelKey]; ok {

--- a/internal/controller/nodetemplate_controller_test.go
+++ b/internal/controller/nodetemplate_controller_test.go
@@ -203,7 +203,7 @@ var _ = Describe("NodeTemplate Controller", func() {
 			L:
 				for _, node := range nodes.Items {
 					for _, taint := range node.Spec.Taints {
-						if taint.Key == "node.cybozu.io/spare" {
+						if taint.Key == SpareTaintKey {
 							continue L
 						}
 					}
@@ -843,7 +843,11 @@ var _ = Describe("NodeTemplate Controller", func() {
 			nodeToUpdate := &corev1.Node{}
 			err = k8sClient.Get(ctx, client.ObjectKey{Name: "node1"}, nodeToUpdate)
 			Expect(err).ToNot(HaveOccurred())
-			nodeToUpdate.Labels["test-label"] = "updated"
+			nodeToUpdate.Spec.Taints = append(nodeToUpdate.Spec.Taints, corev1.Taint{
+				Key:    "extra-taint",
+				Value:  "true",
+				Effect: corev1.TaintEffectNoSchedule,
+			})
 			err = k8sClient.Update(ctx, nodeToUpdate)
 			Expect(err).ToNot(HaveOccurred())
 
@@ -852,7 +856,11 @@ var _ = Describe("NodeTemplate Controller", func() {
 				updatedNode := &corev1.Node{}
 				err := k8sClient.Get(ctx, client.ObjectKey{Name: "node1"}, updatedNode)
 				g.Expect(err).NotTo(HaveOccurred())
-				g.Expect(updatedNode.Labels).To(HaveKeyWithValue("test-label", "foo"))
+				g.Expect(updatedNode.Spec.Taints).To(ContainElement(corev1.Taint{
+					Key:    "extra-taint",
+					Value:  "true",
+					Effect: corev1.TaintEffectNoSchedule,
+				}))
 			}).WithTimeout(10 * time.Second).WithPolling(500 * time.Millisecond).Should(Succeed())
 		})
 
@@ -1190,7 +1198,7 @@ func newNode(name string) NodeBuilder {
 
 func (n NodeBuilder) withSpareTaint() NodeBuilder {
 	n.Spec.Taints = append(n.Spec.Taints, corev1.Taint{
-		Key:    "node.cybozu.io/spare",
+		Key:    SpareTaintKey,
 		Value:  "true",
 		Effect: corev1.TaintEffectNoSchedule,
 	})

--- a/internal/controller/nodetemplate_controller_test.go
+++ b/internal/controller/nodetemplate_controller_test.go
@@ -203,7 +203,7 @@ var _ = Describe("NodeTemplate Controller", func() {
 			L:
 				for _, node := range nodes.Items {
 					for _, taint := range node.Spec.Taints {
-						if taint.Key == SpareTaintKey {
+						if taint.Key == "node.cybozu.io/spare" {
 							continue L
 						}
 					}
@@ -274,7 +274,7 @@ var _ = Describe("NodeTemplate Controller", func() {
 			err = k8sClient.Get(ctx, client.ObjectKey{Name: "test1"}, nt)
 			Expect(err).ToNot(HaveOccurred())
 			for _, condition := range nt.Status.Conditions {
-				if condition.Type == ConditionSufficient {
+				if condition.Type == "Sufficient" {
 					Expect(condition.Status).To(Equal(metav1.ConditionFalse))
 					Expect(condition.Reason).To(Equal("HighPriorityNodeTemplateExists"))
 					break
@@ -286,7 +286,7 @@ var _ = Describe("NodeTemplate Controller", func() {
 			err = k8sClient.Get(ctx, client.ObjectKey{Name: "test2"}, nt)
 			Expect(err).ToNot(HaveOccurred())
 			for _, condition := range nt.Status.Conditions {
-				if condition.Type == ConditionSufficient {
+				if condition.Type == "Sufficient" {
 					Expect(condition.Status).To(Equal(metav1.ConditionFalse))
 					Expect(condition.Reason).To(Equal("NoSpareNodesFound"))
 					break
@@ -314,7 +314,7 @@ var _ = Describe("NodeTemplate Controller", func() {
 				err = k8sClient.Get(ctx, client.ObjectKey{Name: "test1"}, nt)
 				g.Expect(err).ToNot(HaveOccurred())
 				for _, condition := range nt.Status.Conditions {
-					if condition.Type == ConditionSufficient {
+					if condition.Type == "Sufficient" {
 						g.Expect(condition.Status).To(Equal(metav1.ConditionFalse))
 						g.Expect(condition.Reason).To(Equal("NoSpareNodesFound"))
 						break
@@ -436,7 +436,7 @@ var _ = Describe("NodeTemplate Controller", func() {
 			err = k8sClient.Get(ctx, client.ObjectKey{Name: "test"}, nt)
 			Expect(err).ToNot(HaveOccurred())
 			for _, condition := range nt.Status.Conditions {
-				if condition.Type == ConditionSufficient {
+				if condition.Type == "Sufficient" {
 					Expect(condition.Status).To(Equal(metav1.ConditionFalse))
 					Expect(condition.Reason).To(Equal("NoSpareNodesFound"))
 					break
@@ -654,7 +654,7 @@ var _ = Describe("NodeTemplate Controller", func() {
 				err = k8sClient.Get(ctx, client.ObjectKey{Name: "test"}, nt)
 				g.Expect(err).ToNot(HaveOccurred())
 				for _, condition := range nt.Status.Conditions {
-					if condition.Type == ConditionReconcileSuccess {
+					if condition.Type == "ReconcileSuccess" {
 						g.Expect(condition.Status).To(Equal(metav1.ConditionFalse))
 						g.Expect(condition.Reason).To(Equal("ReconcileError"))
 						break
@@ -769,7 +769,7 @@ var _ = Describe("NodeTemplate Controller", func() {
 				err = k8sClient.Get(ctx, client.ObjectKey{Name: "test"}, nt)
 				g.Expect(err).ToNot(HaveOccurred())
 				for _, condition := range nt.Status.Conditions {
-					if condition.Type == ConditionSufficient {
+					if condition.Type == "Sufficient" {
 						g.Expect(condition.Status).To(Equal(metav1.ConditionFalse))
 						g.Expect(condition.Reason).To(Equal("HighPriorityNodeTemplateExists"))
 						break
@@ -1091,7 +1091,7 @@ var _ = Describe("NodeTemplate Controller", func() {
 			Expect(err).ToNot(HaveOccurred())
 			Expect(nodeTemplate.Status.CurrentNodes).To(Equal(0))
 			for _, condition := range nodeTemplate.Status.Conditions {
-				if condition.Type == ConditionSufficient {
+				if condition.Type == "Sufficient" {
 					Expect(condition.Status).To(Equal(metav1.ConditionFalse))
 					Expect(condition.Reason).To(Equal("NoSpareNodesFound"))
 				}
@@ -1198,7 +1198,7 @@ func newNode(name string) NodeBuilder {
 
 func (n NodeBuilder) withSpareTaint() NodeBuilder {
 	n.Spec.Taints = append(n.Spec.Taints, corev1.Taint{
-		Key:    SpareTaintKey,
+		Key:    "node.cybozu.io/spare",
 		Value:  "true",
 		Effect: corev1.TaintEffectNoSchedule,
 	})

--- a/internal/controller/utils.go
+++ b/internal/controller/utils.go
@@ -1,0 +1,45 @@
+package controller
+
+import (
+	"reflect"
+	"sort"
+
+	corev1 "k8s.io/api/core/v1"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
+)
+
+func sortTaints(ts []corev1.Taint) []corev1.Taint {
+	out := make([]corev1.Taint, len(ts))
+	copy(out, ts)
+	sort.Slice(out, func(i, j int) bool {
+		if out[i].Key != out[j].Key {
+			return out[i].Key < out[j].Key
+		}
+		if out[i].Value != out[j].Value {
+			return out[i].Value < out[j].Value
+		}
+		return out[i].Effect < out[j].Effect
+	})
+	return out
+}
+
+func taintsEqual(a, b []corev1.Taint) bool {
+	return reflect.DeepEqual(sortTaints(a), sortTaints(b))
+}
+
+func taintChangePredicate() predicate.Predicate {
+	return predicate.Funcs{
+		CreateFunc: func(e event.CreateEvent) bool { return true },
+		DeleteFunc: func(e event.DeleteEvent) bool { return true },
+		UpdateFunc: func(e event.UpdateEvent) bool {
+			oldNode, okOld := e.ObjectOld.(*corev1.Node)
+			newNode, okNew := e.ObjectNew.(*corev1.Node)
+			if !okOld || !okNew {
+				return false
+			}
+			return !taintsEqual(oldNode.Spec.Taints, newNode.Spec.Taints)
+		},
+		GenericFunc: func(e event.GenericEvent) bool { return false },
+	}
+}

--- a/internal/controller/utils_test.go
+++ b/internal/controller/utils_test.go
@@ -52,15 +52,15 @@ var _ = Describe("Utilities functions tests", func() {
 			taints2 := []corev1.Taint{
 				{Key: "key1", Value: "value2", Effect: corev1.TaintEffectNoSchedule},
 			}
-			taint3 := []corev1.Taint{
+			taints3 := []corev1.Taint{
 				{Key: "key2", Value: "value1", Effect: corev1.TaintEffectNoSchedule},
 			}
-			taint4 := []corev1.Taint{
+			taints4 := []corev1.Taint{
 				{Key: "key1", Value: "value1", Effect: corev1.TaintEffectPreferNoSchedule},
 			}
 			Expect(taintsEqual(taints1, taints2)).To(BeFalse())
-			Expect(taintsEqual(taints1, taint3)).To(BeFalse())
-			Expect(taintsEqual(taints1, taint4)).To(BeFalse())
+			Expect(taintsEqual(taints1, taints3)).To(BeFalse())
+			Expect(taintsEqual(taints1, taints4)).To(BeFalse())
 		})
 		It("should return true for empty and nil taint slices", func() {
 			Expect(taintsEqual([]corev1.Taint{}, []corev1.Taint{})).To(BeTrue())

--- a/internal/controller/utils_test.go
+++ b/internal/controller/utils_test.go
@@ -1,0 +1,41 @@
+package controller
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+)
+
+var _ = Describe("Utilities functions tests", func() {
+	Context("sortTaints function", func() {
+		It("should sort taints correctly", func() {
+			taints := []corev1.Taint{
+				{Key: "b", Value: "2", Effect: corev1.TaintEffectNoSchedule},
+				{Key: "a", Value: "2", Effect: corev1.TaintEffectNoSchedule},
+				{Key: "a", Value: "1", Effect: corev1.TaintEffectPreferNoSchedule},
+				{Key: "a", Value: "1", Effect: corev1.TaintEffectNoSchedule},
+			}
+			sorted := sortTaints(taints)
+			expected := []corev1.Taint{
+				{Key: "a", Value: "1", Effect: corev1.TaintEffectNoSchedule},
+				{Key: "a", Value: "1", Effect: corev1.TaintEffectPreferNoSchedule},
+				{Key: "a", Value: "2", Effect: corev1.TaintEffectNoSchedule},
+				{Key: "b", Value: "2", Effect: corev1.TaintEffectNoSchedule},
+			}
+			Expect(sorted).To(Equal(expected))
+		})
+	})
+	Context("taintsEqual function", func() {
+		It("should return true for equal taint slices", func() {
+			taints1 := []corev1.Taint{
+				{Key: "key1", Value: "value1", Effect: corev1.TaintEffectNoSchedule},
+				{Key: "key2", Value: "value2", Effect: corev1.TaintEffectPreferNoSchedule},
+			}
+			taints2 := []corev1.Taint{
+				{Key: "key2", Value: "value2", Effect: corev1.TaintEffectPreferNoSchedule},
+				{Key: "key1", Value: "value1", Effect: corev1.TaintEffectNoSchedule},
+			}
+			Expect(taintsEqual(taints1, taints2)).To(BeTrue())
+		})
+	})
+})

--- a/internal/controller/utils_test.go
+++ b/internal/controller/utils_test.go
@@ -24,6 +24,14 @@ var _ = Describe("Utilities functions tests", func() {
 			}
 			Expect(sorted).To(Equal(expected))
 		})
+		It("should handle nil taint slice", func() {
+			sorted := sortTaints(nil)
+			Expect(sorted).To(BeEmpty())
+		})
+		It("should handle empty taint slice", func() {
+			sorted := sortTaints([]corev1.Taint{})
+			Expect(sorted).To(BeEmpty())
+		})
 	})
 	Context("taintsEqual function", func() {
 		It("should return true for equal taint slices", func() {
@@ -36,6 +44,25 @@ var _ = Describe("Utilities functions tests", func() {
 				{Key: "key1", Value: "value1", Effect: corev1.TaintEffectNoSchedule},
 			}
 			Expect(taintsEqual(taints1, taints2)).To(BeTrue())
+		})
+		It("should return false for different taint slices", func() {
+			taints1 := []corev1.Taint{
+				{Key: "key1", Value: "value1", Effect: corev1.TaintEffectNoSchedule},
+			}
+			taints2 := []corev1.Taint{
+				{Key: "key1", Value: "value2", Effect: corev1.TaintEffectNoSchedule},
+			}
+			taint3 := []corev1.Taint{
+				{Key: "key2", Value: "value1", Effect: corev1.TaintEffectNoSchedule},
+			}
+
+			Expect(taintsEqual(taints1, taints2)).To(BeFalse())
+			Expect(taintsEqual(taints1, taint3)).To(BeFalse())
+		})
+		It("should return true for empty and nil taint slices", func() {
+			Expect(taintsEqual([]corev1.Taint{}, []corev1.Taint{})).To(BeTrue())
+			Expect(taintsEqual(nil, nil)).To(BeTrue())
+			Expect(taintsEqual([]corev1.Taint{}, nil)).To(BeTrue())
 		})
 	})
 })

--- a/internal/controller/utils_test.go
+++ b/internal/controller/utils_test.go
@@ -55,9 +55,12 @@ var _ = Describe("Utilities functions tests", func() {
 			taint3 := []corev1.Taint{
 				{Key: "key2", Value: "value1", Effect: corev1.TaintEffectNoSchedule},
 			}
-
+			taint4 := []corev1.Taint{
+				{Key: "key1", Value: "value1", Effect: corev1.TaintEffectPreferNoSchedule},
+			}
 			Expect(taintsEqual(taints1, taints2)).To(BeFalse())
 			Expect(taintsEqual(taints1, taint3)).To(BeFalse())
+			Expect(taintsEqual(taints1, taint4)).To(BeFalse())
 		})
 		It("should return true for empty and nil taint slices", func() {
 			Expect(taintsEqual([]corev1.Taint{}, []corev1.Taint{})).To(BeTrue())


### PR DESCRIPTION
- fix bug that the reconciler does not triggerd when taints of the node changes because node resource does not have `.metadata.generation`.
  - instead of using predicate.GenerationChangedPredicate, taintChangePredicate is implemented.
- remove unnecessary `MaxConcurrentReconciles` in NodeReconciler.
- add tests for the changes above.