### PR TITLE
add metrics about NodeTemplate annotations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,4 @@ go.work
 *~
 
 e2e/bin/*
+cover.out

--- a/e2e/manifests/nodetemplate.yaml
+++ b/e2e/manifests/nodetemplate.yaml
@@ -2,6 +2,8 @@ apiVersion: nyallocator.cybozu.io/v1
 kind: NodeTemplate
 metadata:
   name: control-plane
+  annotations:
+    test-annotation: "true"
 spec:
   dryRun: false
   priority: 100

--- a/e2e/nyallocator_test.go
+++ b/e2e/nyallocator_test.go
@@ -99,6 +99,7 @@ var _ = Describe("nyallocator e2e test", func() {
 			g.Expect(string(metrics)).To(ContainSubstring(`nyallocator_sufficient_nodes{nodetemplate="control-plane"} 1`))
 			g.Expect(string(metrics)).To(ContainSubstring(`nyallocator_spare_nodes{nodetemplate="control-plane"} 0`))
 			g.Expect(string(metrics)).To(ContainSubstring(`nyallocator_reconcile_success{nodetemplate="control-plane"} 1`))
+			g.Expect(string(metrics)).To(ContainSubstring(`nyallocator_annotations{key="test-annotation",nodetemplate="control-plane",value="true"} 1`))
 
 			g.Expect(string(metrics)).To(ContainSubstring(`nyallocator_current_nodes{nodetemplate="cs"} 2`))
 			g.Expect(string(metrics)).To(ContainSubstring(`nyallocator_desired_nodes{nodetemplate="cs"} 2`))

--- a/internal/controller/metrics.go
+++ b/internal/controller/metrics.go
@@ -35,6 +35,11 @@ var (
 		Name:      "reconcile_success",
 		Help:      "Whether reconciliations of the NodeTemplate is successful or not",
 	}, []string{"nodetemplate"})
+	Annotations = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Namespace: metricsNamespace,
+		Name:      "annotations",
+		Help:      "Annotations of the NodeTemplate",
+	}, []string{"nodetemplate", "key", "value"})
 )
 
 func init() {
@@ -43,4 +48,5 @@ func init() {
 	metrics.Registry.MustRegister(SufficientNodesVec)
 	metrics.Registry.MustRegister(SpareNodesVec)
 	metrics.Registry.MustRegister(ReconcileSuccessVec)
+	metrics.Registry.MustRegister(Annotations)
 }

--- a/internal/controller/nodetemplate_controller.go
+++ b/internal/controller/nodetemplate_controller.go
@@ -403,6 +403,10 @@ func (r *NodeTemplateReconciler) updateMetrics(nodeTemplate *nyallocatorv1.NodeT
 			ReconcileSuccessVec.WithLabelValues(nodeTemplate.Name).Set(0)
 		}
 	}
+	Annotations.DeletePartialMatch(map[string]string{"nodetemplate": nodeTemplate.Name})
+	for k, v := range nodeTemplate.Annotations {
+		Annotations.WithLabelValues(nodeTemplate.Name, k, v).Set(1)
+	}
 }
 
 func (r *NodeTemplateReconciler) removeMetrics(nodeTemplate *nyallocatorv1.NodeTemplate) {
@@ -411,6 +415,7 @@ func (r *NodeTemplateReconciler) removeMetrics(nodeTemplate *nyallocatorv1.NodeT
 	DesiredNodesVec.DeleteLabelValues(nodeTemplate.Name)
 	SpareNodesVec.DeleteLabelValues(nodeTemplate.Name)
 	ReconcileSuccessVec.DeleteLabelValues(nodeTemplate.Name)
+	Annotations.DeletePartialMatch(map[string]string{"nodetemplate": nodeTemplate.Name})
 }
 
 func isSufficient(nodeTemplate *nyallocatorv1.NodeTemplate) bool {

--- a/internal/controller/nodetemplate_controller_test.go
+++ b/internal/controller/nodetemplate_controller_test.go
@@ -1189,7 +1189,7 @@ var _ = Describe("NodeTemplate Controller", func() {
 			}
 			for _, node := range nodes {
 				err := k8sClient.Create(ctx, &node)
-				Expect(err).ToNot(HaveOccurred())
+				Expect(err).NotTo(HaveOccurred())
 			}
 			By("creating NodeTemplate")
 			nodeTemplate := &nyallocatorv1.NodeTemplate{
@@ -1212,17 +1212,17 @@ var _ = Describe("NodeTemplate Controller", func() {
 				},
 			}
 			err := k8sClient.Create(ctx, nodeTemplate)
-			Expect(err).ToNot(HaveOccurred())
+			Expect(err).NotTo(HaveOccurred())
 
 			By("checking NodeTemplate status")
 			checkNodeTemplateStatus("test", true)
 
 			By("checking metrics are exposed correctly")
 			resp, err := http.Get("http://localhost:8080/metrics")
-			Expect(err).ToNot(HaveOccurred())
+			Expect(err).NotTo(HaveOccurred())
 			defer resp.Body.Close()
 			body, err := io.ReadAll(resp.Body)
-			Expect(err).ToNot(HaveOccurred())
+			Expect(err).NotTo(HaveOccurred())
 			Expect(string(body)).To(ContainSubstring("nyallocator_desired_nodes{nodetemplate=\"test\"} 2"))
 			Expect(string(body)).To(ContainSubstring("nyallocator_current_nodes{nodetemplate=\"test\"} 2"))
 			Expect(string(body)).To(ContainSubstring("nyallocator_sufficient_nodes{nodetemplate=\"test\"} 1"))
@@ -1234,25 +1234,25 @@ var _ = Describe("NodeTemplate Controller", func() {
 			By("Deleting Annotation and checking metrics are updated")
 			nt := &nyallocatorv1.NodeTemplate{}
 			err = k8sClient.Get(ctx, client.ObjectKey{Name: "test"}, nt)
-			Expect(err).ToNot(HaveOccurred())
+			Expect(err).NotTo(HaveOccurred())
 			delete(nt.Annotations, "test-annotation1")
 			err = k8sClient.Update(ctx, nt)
-			Expect(err).ToNot(HaveOccurred())
+			Expect(err).NotTo(HaveOccurred())
 			Eventually(func(g Gomega) {
 				resp, err := http.Get("http://localhost:8080/metrics")
-				g.Expect(err).ToNot(HaveOccurred())
+				g.Expect(err).NotTo(HaveOccurred())
 				defer resp.Body.Close()
 				body, err := io.ReadAll(resp.Body)
-				g.Expect(err).ToNot(HaveOccurred())
-				g.Expect(string(body)).ToNot(ContainSubstring("nyallocator_annotations{key=\"test-annotation1\",nodetemplate=\"test\",value=\"foo\"} 1"))
+				g.Expect(err).NotTo(HaveOccurred())
+				g.Expect(string(body)).NotTo(ContainSubstring("nyallocator_annotations{key=\"test-annotation1\",nodetemplate=\"test\",value=\"foo\"} 1"))
 				g.Expect(string(body)).To(ContainSubstring("nyallocator_annotations{key=\"test-annotation2\",nodetemplate=\"test\",value=\"bar\"} 1"))
 			}).WithTimeout(10 * time.Second).WithPolling(500 * time.Millisecond).Should(Succeed())
 
 			By("Deleting NodeTemplate and checking metrics are removed")
 			err = k8sClient.Get(ctx, client.ObjectKey{Name: "test"}, nt)
-			Expect(err).ToNot(HaveOccurred())
+			Expect(err).NotTo(HaveOccurred())
 			err = k8sClient.Delete(ctx, nt)
-			Expect(err).ToNot(HaveOccurred())
+			Expect(err).NotTo(HaveOccurred())
 
 			By("checking NodeTemplate is deleted")
 			Eventually(func(g Gomega) {
@@ -1264,11 +1264,11 @@ var _ = Describe("NodeTemplate Controller", func() {
 
 			Eventually(func(g Gomega) {
 				resp, err := http.Get("http://localhost:8080/metrics")
-				g.Expect(err).ToNot(HaveOccurred())
+				g.Expect(err).NotTo(HaveOccurred())
 				defer resp.Body.Close()
 				body, err := io.ReadAll(resp.Body)
-				g.Expect(err).ToNot(HaveOccurred())
-				g.Expect(string(body)).ToNot(ContainSubstring("nyallocator_annotations"))
+				g.Expect(err).NotTo(HaveOccurred())
+				g.Expect(string(body)).NotTo(ContainSubstring("nyallocator_annotations"))
 			}).WithTimeout(10 * time.Second).WithPolling(500 * time.Millisecond).Should(Succeed())
 		})
 	})

--- a/internal/controller/nodetemplate_controller_test.go
+++ b/internal/controller/nodetemplate_controller_test.go
@@ -1179,6 +1179,98 @@ var _ = Describe("NodeTemplate Controller", func() {
 				g.Expect(string(body)).NotTo(ContainSubstring("nyallocator_reconcile_success{nodetemplate=\"test\"}"))
 			}).WithTimeout(10 * time.Second).WithPolling(500 * time.Millisecond).Should(Succeed())
 		})
+
+		It("should check annotations metrics", func() {
+			By("creating Node")
+			nodes := []corev1.Node{
+				newNode("node1").withLabel(map[string]string{"node-role.kubernetes.io/worker": "true"}).withSpareTaint().build(),
+				newNode("node2").withLabel(map[string]string{"node-role.kubernetes.io/worker": "true"}).withSpareTaint().build(),
+				newNode("node3").withLabel(map[string]string{"node-role.kubernetes.io/worker": "true"}).withSpareTaint().build(),
+			}
+			for _, node := range nodes {
+				err := k8sClient.Create(ctx, &node)
+				Expect(err).ToNot(HaveOccurred())
+			}
+			By("creating NodeTemplate")
+			nodeTemplate := &nyallocatorv1.NodeTemplate{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test",
+					Annotations: map[string]string{
+						"test-annotation1": "foo",
+						"test-annotation2": "bar",
+					},
+				},
+				Spec: nyallocatorv1.NodeTemplateSpec{
+					DryRun:   false,
+					Priority: 1,
+					Nodes:    2,
+					Selector: &metav1.LabelSelector{
+						MatchLabels: map[string]string{
+							"node-role.kubernetes.io/worker": "true",
+						},
+					},
+				},
+			}
+			err := k8sClient.Create(ctx, nodeTemplate)
+			Expect(err).ToNot(HaveOccurred())
+
+			By("checking NodeTemplate status")
+			checkNodeTemplateStatus("test", true)
+
+			By("checking metrics are exposed correctly")
+			resp, err := http.Get("http://localhost:8080/metrics")
+			Expect(err).ToNot(HaveOccurred())
+			defer resp.Body.Close()
+			body, err := io.ReadAll(resp.Body)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(string(body)).To(ContainSubstring("nyallocator_desired_nodes{nodetemplate=\"test\"} 2"))
+			Expect(string(body)).To(ContainSubstring("nyallocator_current_nodes{nodetemplate=\"test\"} 2"))
+			Expect(string(body)).To(ContainSubstring("nyallocator_sufficient_nodes{nodetemplate=\"test\"} 1"))
+			Expect(string(body)).To(ContainSubstring("nyallocator_spare_nodes{nodetemplate=\"test\"} 1"))
+			Expect(string(body)).To(ContainSubstring("nyallocator_reconcile_success{nodetemplate=\"test\"} 1"))
+			Expect(string(body)).To(ContainSubstring("nyallocator_annotations{key=\"test-annotation1\",nodetemplate=\"test\",value=\"foo\"} 1"))
+			Expect(string(body)).To(ContainSubstring("nyallocator_annotations{key=\"test-annotation2\",nodetemplate=\"test\",value=\"bar\"} 1"))
+
+			By("Deleting Annotation and checking metrics are updated")
+			nt := &nyallocatorv1.NodeTemplate{}
+			err = k8sClient.Get(ctx, client.ObjectKey{Name: "test"}, nt)
+			Expect(err).ToNot(HaveOccurred())
+			delete(nt.Annotations, "test-annotation1")
+			err = k8sClient.Update(ctx, nt)
+			Expect(err).ToNot(HaveOccurred())
+			Eventually(func(g Gomega) {
+				resp, err := http.Get("http://localhost:8080/metrics")
+				g.Expect(err).ToNot(HaveOccurred())
+				defer resp.Body.Close()
+				body, err := io.ReadAll(resp.Body)
+				g.Expect(err).ToNot(HaveOccurred())
+				g.Expect(string(body)).ToNot(ContainSubstring("nyallocator_annotations{key=\"test-annotation1\",nodetemplate=\"test\",value=\"foo\"} 1"))
+				g.Expect(string(body)).To(ContainSubstring("nyallocator_annotations{key=\"test-annotation2\",nodetemplate=\"test\",value=\"bar\"} 1"))
+			}).WithTimeout(10 * time.Second).WithPolling(500 * time.Millisecond).Should(Succeed())
+
+			By("Deleting NodeTemplate and checking metrics are removed")
+			err = k8sClient.Get(ctx, client.ObjectKey{Name: "test"}, nt)
+			Expect(err).ToNot(HaveOccurred())
+			err = k8sClient.Delete(ctx, nt)
+			Expect(err).ToNot(HaveOccurred())
+
+			By("checking NodeTemplate is deleted")
+			Eventually(func(g Gomega) {
+				nt := &nyallocatorv1.NodeTemplate{}
+				err := k8sClient.Get(ctx, client.ObjectKey{Name: "test"}, nt)
+				g.Expect(err).To(HaveOccurred())
+				g.Expect(apierrors.IsNotFound(err)).To(BeTrue())
+			}).WithTimeout(10 * time.Second).WithPolling(500 * time.Millisecond).Should(Succeed())
+
+			Eventually(func(g Gomega) {
+				resp, err := http.Get("http://localhost:8080/metrics")
+				g.Expect(err).ToNot(HaveOccurred())
+				defer resp.Body.Close()
+				body, err := io.ReadAll(resp.Body)
+				g.Expect(err).ToNot(HaveOccurred())
+				g.Expect(string(body)).ToNot(ContainSubstring("nyallocator_annotations"))
+			}).WithTimeout(10 * time.Second).WithPolling(500 * time.Millisecond).Should(Succeed())
+		})
 	})
 })
 


### PR DESCRIPTION
Add metrics about NodeTemplate's annotation in order to use it in prometheus alert rules.